### PR TITLE
Use socket.io library from node_modules, versus CDN

### DIFF
--- a/site/build/buttons.html
+++ b/site/build/buttons.html
@@ -3,7 +3,7 @@
   <head>
     <link href='/auxiliary.css' rel='stylesheet' type='text/css'>
     <title>Emoto Booth: Keep / Kill Sessions</title>
-    <script src="https://cdn.socket.io/socket.io-1.4.5.js"></script>
+    <script src="/socket.io/socket.io.js"></script>
   </head>
   <body>
     <button class="keep-button" value="Keep" onClick="keep()">Keep</button>

--- a/site/build/index.html
+++ b/site/build/index.html
@@ -3,7 +3,7 @@
   <head>
     <title>Emoto Booth</title>
     <link href='https://fonts.googleapis.com/css?family=Roboto:400,300,500,700,100,100italic,300italic,400italic,500italic,700italic,900italic,900|Roboto+Mono:400,100,100italic,300,300italic,400italic,500,500italic,700,700italic&subset=latin,latin-ext' rel='stylesheet' type='text/css'>
-    <script src="https://cdn.socket.io/socket.io-1.4.5.js"></script>
+    <script src="/socket.io/socket.io.js"></script>
   </head>
   <body>
     <main id="main">

--- a/site/build/single.html
+++ b/site/build/single.html
@@ -3,7 +3,7 @@
   <head>
     <title>Emoto Booth</title>
     <link href='https://fonts.googleapis.com/css?family=Roboto:400,300,500,700,100,100italic,300italic,400italic,500italic,700italic,900italic,900|Roboto+Mono:400,100,100italic,300,300italic,400italic,500,500italic,700,700italic&subset=latin,latin-ext' rel='stylesheet' type='text/css'>
-    <script src="https://cdn.socket.io/socket.io-1.4.5.js"></script>
+    <script src="/socket.io/socket.io.js"></script>
   </head>
   <body>
     <main class="single" id="main">

--- a/site/socket-test.html
+++ b/site/socket-test.html
@@ -1,4 +1,4 @@
-<script src="https://cdn.socket.io/socket.io-1.4.5.js"></script>
+<script src="/socket.io/socket.io.js"></script>
 <script>
   var socket = io.connect('http://localhost:8080');
   socket.on('new_image', function (data) {


### PR DESCRIPTION
The CDN version of socket.io (https://cdn.socket.io/socket.io-1.4.5.js) has been deprecated; this update keeps things simple by leveraging the socket.io library already present in node_modules.

Tested locally, on the following paths:
http://localhost:8080/
http://localhost:8081/active
http://localhost:8080/buttons